### PR TITLE
パスワードの正規表現にハイフンとアンダーバーを許可

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
     validates :birthday
   end
 
-  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
+  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d_-]+\z/i.freeze
   validates_format_of :password, with: PASSWORD_REGEX, message: 'は半角英数記号で入力してください'
 
   has_many :routines


### PR DESCRIPTION
# What
パスワードの正規表現を修正

# Why
ランダム生成されたパスワードにハイフンとアンダーバーが含まれた際に新規登録できないのを修正するため