### PR TITLE
いいね機能の修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
     { user: user, sns: sns }
   end
 
-  def liked_by?(routine_id)
-    Like.where(routine_id: routine_id).exists?
+  def liked_by?(user_id, routine_id)
+    Like.where(user_id: user_id, routine_id: routine_id).exists?
   end
 end

--- a/app/views/routines/_like.html.erb
+++ b/app/views/routines/_like.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.liked_by?(routine.id) %>
+<% if current_user.liked_by?(current_user.id, routine.id) %>
   <%= link_to destroy_like_path(routine.id), method: :delete, remote: true do %>
     <i class="fas fa-heart unlike-btn"></i>
   <% end %>


### PR DESCRIPTION
# What
いいね機能の修正

# Why
いいね機能として致命的なミスがあったため。
具体的には、他のユーザがいいねをしたルーティンに対して、さらに他のユーザーがいいねをできない不具合であった。